### PR TITLE
Fix subtitle not detected when dot in filename

### DIFF
--- a/src/dakara_feeder/directory_lister.py
+++ b/src/dakara_feeder/directory_lister.py
@@ -35,17 +35,17 @@ def list_directory(path):
     return listing
 
 
-def get_path_without_extension(f):
-    """Remove extension from file path
+def get_path_without_extension(path):
+    """Remove extension from file path.
 
     Args:
         path (path.Path): Path to a file.
 
     Returns:
-        path to the file without the extension.
-        'directory/file0.mkv' will return 'directory/file0'
+        path.Path: path to the file without the extension.
+        'directory/file0.mkv' will return 'directory/file0'.
     """
-    return f.dirname() / f.stem
+    return path.dirname() / path.stem
 
 
 def get_main_type(file):

--- a/src/dakara_feeder/directory_lister.py
+++ b/src/dakara_feeder/directory_lister.py
@@ -36,6 +36,15 @@ def list_directory(path):
 
 
 def get_path_without_extension(f):
+    """Remove extension from file path
+
+    Args:
+        path (path.Path): Path to a file.
+
+    Returns:
+        path to the file without the extension.
+        'directory/file0.mkv' will return 'directory/file0'
+    """
     return f.dirname() / f.stem
 
 

--- a/src/dakara_feeder/directory_lister.py
+++ b/src/dakara_feeder/directory_lister.py
@@ -21,18 +21,22 @@ def list_directory(path):
     """
     logger.debug("Listing '%s'", path)
     files_list = [p.relpath(path) for p in path.walkfiles()]
-    files_list.sort()
+    files_list.sort(key=lambda f: (get_path_without_extension(f), f))
     logger.debug("Listed %i files", len(files_list))
 
     listing = [
         item
-        for _, files in groupby(files_list, lambda f: f.dirname() / f.stem)
+        for _, files in groupby(files_list, get_path_without_extension)
         for item in group_by_type(files, path)
     ]
 
     logger.debug("Found %i different videos", len(listing))
 
     return listing
+
+
+def get_path_without_extension(f):
+    return f.dirname() / f.stem
 
 
 def get_main_type(file):

--- a/tests/test_directory_lister.py
+++ b/tests/test_directory_lister.py
@@ -337,23 +337,24 @@ class GroupByTypeTestCase(TestCase):
         )
 
 
-def get_main_type_mock(filePath):
-    """ Detect audio or video type from file extension.
+def get_main_type_mock(path):
+    """Detect audio or video type from file extension.
+
     Used to mock real method which needs actual files to be present.
 
     Args:
         path (path.Path): Path to a file.
 
     Returns:
-        "video" if file extension is "mp4" or "mkv",
+        str: "video" if file extension is "mp4" or "mkv",
         "audio" if file extension is "ogg" or "flac",
         None otherwise.
     """
-    ext = filePath.ext
+    ext = path.ext
 
     if ext in [".mp4", ".mkv"]:
         return "video"
-    elif ext in [".ogg", ".flac"]:
+    if ext in [".ogg", ".flac"]:
         return "audio"
 
     return None


### PR DESCRIPTION
Files `f.a` and `f.c` where not grouped together if a third file `f.b.xxx` was present

This is because the file were sorted by filename, but grouped by stem.

The files were sorted as
```
f.a
f.b.xxx
f.c
```

so even if `f.a` and `f.c` share the same stem `f`, because a file with a different stem `f.b`  was found between, the `groupby` would not work.

To solve the isssue, the list is now sorted by stem.