### PR TITLE
Support Mac

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -100,8 +100,8 @@ for:
       # install dependencies for test
       - "python -m pip install -e \".[tests]\""
 
-      # check version of dependencies if requested
-      - "if $INTEGRATION_TEST; then mediainfo --version; fi"
+      # # check version of dependencies if requested
+      # - "if $INTEGRATION_TEST; then mediainfo --version; fi"
 
     test_script:
       # run tests

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,10 +25,6 @@ environment:
     - PYTHON: "3.10"
       INTEGRATION_TEST: true
 
-# check current python version
-init:
-  - "py -%PYTHON% --version"
-
 for:
   - matrix:
       only:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -93,7 +93,6 @@ for:
     install:
       # install system dependencies if requested
       - "if $INTEGRATION_TEST; then brew install --cask mediainfo; fi"
-      - "if $INTEGRATION_TEST; then brew install ffmpeg; fi"
 
       # the features used in setup.cfg require a recent enough version of setuptools
       - "python -m pip install --upgrade \"setuptools>=46.4.0\""

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,7 @@ version: 1.8.0-dev-{build}
 
 image:
   - Ubuntu
+  - macos
   - Visual Studio 2019
 
 build: false
@@ -20,6 +21,8 @@ environment:
     - PYTHON: "3.8"
       INTEGRATION_TEST: false
     - PYTHON: "3.9"
+      INTEGRATION_TEST: false
+    - PYTHON: "3.10"
       INTEGRATION_TEST: true
 
 # check current python version
@@ -77,7 +80,57 @@ for:
 
   - matrix:
       only:
+        - image: macos
+          PYTHON: "3.10"
+
+    cache:
+      # enable cache for Python dependencies
+      - "$HOME/Library/Caches/pip"
+
+    init:
+      # load virtual env
+      - "source $HOME/venv$PYTHON/bin/activate"
+
+      # check current python version
+      - "python --version"
+
+    install:
+      # install system dependencies if requested
+      - "if $INTEGRATION_TEST; then brew install --cask mediainfo; fi"
+      - "if $INTEGRATION_TEST; then brew install ffmpeg; fi"
+
+      # the features used in setup.cfg require a recent enough version of setuptools
+      - "python -m pip install --upgrade \"setuptools>=46.4.0\""
+
+      # install dependencies for test
+      - "python -m pip install -e \".[tests]\""
+
+      # check version of dependencies if requested
+      - "if $INTEGRATION_TEST; then ffprobe -version; fi"
+      - "if $INTEGRATION_TEST; then mediainfo --version; fi"
+
+    test_script:
+      # run tests
+      - "if $INTEGRATION_TEST; then python -m pytest -v --cov-report term; else python -m pytest -v --cov-report term tests/unit; fi"
+
+      # run commands
+      - "python -m dakara_feeder --version"
+      - "dakara-feeder --version"
+
+      # run code formatting tests
+      - "python -m isort . --check"
+      - "python -m black . --check"
+      - "python -m flake8"
+
+    after_test:
+      # upload coverage stats to codecov.io
+      # codecov token is stored in appveyor settings
+      - "python -m codecov"
+
+  - matrix:
+      only:
         - image: Visual Studio 2019
+          PYTHON: "3.10"
 
     cache:
       # enable cache for Python dependencies

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -101,7 +101,6 @@ for:
       - "python -m pip install -e \".[tests]\""
 
       # check version of dependencies if requested
-      - "if $INTEGRATION_TEST; then ffprobe -version; fi"
       - "if $INTEGRATION_TEST; then mediainfo --version; fi"
 
     test_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@
 
 ## Unreleased
 
+### Update notes
+
+The project uses now a library to manage user directories on the different operating systems, the location was modified for Windows:
+
+```cmd
+# cmd
+mkdir %APPDATA%\DakaraProject
+move %APPDATA%\Dakara %APPDATA%\DakaraProject\dakara
+# powershell
+mkdir $env:APPDATA\DakaraProject
+mv $env:APPDATA\Dakara $env:APPDATA\DakaraProject\dakara
+```
+
 ### Added
 
 - Automatically prune artists and works without songs on server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 - Feed tags with command `dakara-feeder feed tags`.
 - Feed work types with command `dakara-feeder feed work-types`.
 - Feed works with command `dakara-feeder feed works`.
+- Python 3.10 support.
+- Mac support.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ It is strongly recommended to use the Dakara feeder within a virtual environment
 
 ### Install
 
+Please ensure you have a recent enough version of `setuptools`:
+
+```sh
+pip install --upgrade "setuptools>=46.4.0"
+```
+
 Install the package with:
 
 ```sh
@@ -85,7 +91,7 @@ dakara-feeder create-config
 python -m dakara_feeder create-config
 ```
 
-and complete it with your values. The file is stored in your user space: `~/.config/dakara` on Linux or `$APPDATA\Dakara` on Windows.
+and complete it with your values. The file is stored in your user space: `~/.config/dakara` on Linux, `~/Library/Preferences/dakara` on Mac, or `$APPDATA\DakaraProject\dakara` on Windows.
 
 The data extracted from songs are very limited in this package by default, as data can be stored in various ways in song files. You are encouraged to make your own parser, see next subsection.
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Other important parts of the project include:
 
 ### System requirements
 
-* Python3, to make everything up and running (supported versions: 3.7, 3.8 and 3.9);
+* Python3, to make everything up and running (supported versions: 3.7, 3.8, 3.9 and 3.10);
 * [ffmpeg](https://www.ffmpeg.org/), to extract lyrics and extract metadata from files (preferred way);
 * [MediaInfo](https://mediaarea.net/fr/MediaInfo/), to extract metadata from files (slower, alternative way, may not work on Windows).
 
-Linux and Windows are supported.
+Linux, Mac and Windows are supported.
 
 ### Virtual environment
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
         Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8
         Programming Language :: Python :: 3.9
+        Programming Language :: Python :: 3.10
         Operating System :: OS Independent
         Environment :: Console
         Intended Audience :: Developers

--- a/src/dakara_feeder/customization.py
+++ b/src/dakara_feeder/customization.py
@@ -220,7 +220,7 @@ def import_from_module(object_module_name):
     return custom_object
 
 
-class InvalidObjectModuleNameError(DakaraError, ImportError, AttributeError):
+class InvalidObjectModuleNameError(DakaraError):
     """Error when the object requested does not exist."""
 
 

--- a/src/dakara_feeder/json.py
+++ b/src/dakara_feeder/json.py
@@ -24,7 +24,7 @@ def get_json_file_content(file_path, key=None):
             content of the JSON file.
     """
     try:
-        content = json.loads(file_path.text())
+        content = json.loads(file_path.read_text())
 
     except FileNotFoundError as error:
         raise JsonFileNotFoundError(

--- a/src/dakara_feeder/subtitle/extraction.py
+++ b/src/dakara_feeder/subtitle/extraction.py
@@ -94,7 +94,7 @@ class FFmpegSubtitleExtractor(SubtitleExtractor):
                 return cls()
 
             # otherwise extract content
-            return cls(output_file_path.text())
+            return cls(output_file_path.read_text())
 
 
 class FFmpegNotInstalledError(DakaraError):

--- a/src/dakara_feeder/subtitle/parsing.py
+++ b/src/dakara_feeder/subtitle/parsing.py
@@ -87,7 +87,7 @@ class TXTSubtitleParser(SubtitleParser):
         Returns:
             TXTSubtitleParser: Instance of the class for the given file.
         """
-        return cls(filepath.text())
+        return cls(filepath.read_text())
 
     @classmethod
     def parse_string(cls, filecontent):

--- a/src/dakara_feeder/yaml.py
+++ b/src/dakara_feeder/yaml.py
@@ -22,7 +22,7 @@ def get_yaml_file_content(file_path, key=None):
             content of the YAML file.
     """
     try:
-        content = yaml.safe_load(file_path.text())
+        content = yaml.safe_load(file_path.read_text())
 
     except FileNotFoundError as error:
         raise YamlFileNotFoundError(

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -12,15 +12,15 @@ from dakara_feeder.json import (
 )
 
 
-@patch.object(Path, "text", autoset=True)
+@patch.object(Path, "read_text", autoset=True)
 class GetJsonFileContentTestCase(TestCase):
     """Test the get_json_file_content function."""
 
-    def test_get(self, mocked_text):
+    def test_get(self, mocked_read_text):
         """Test to get a JSON file."""
         # create the mock
         content = {"name": "tag1"}
-        mocked_text.return_value = dumps(content)
+        mocked_read_text.return_value = dumps(content)
 
         # call the method
         content_parsed = get_json_file_content(Path("path/to/file"))
@@ -29,12 +29,12 @@ class GetJsonFileContentTestCase(TestCase):
         self.assertDictEqual(content, content_parsed)
 
         # assert the call
-        mocked_text.assert_called_with()
+        mocked_read_text.assert_called_with()
 
-    def test_get_error_not_found(self, mocked_text):
+    def test_get_error_not_found(self, mocked_read_text):
         """Test to get a JSON file that does not exist."""
         # create the mock
-        mocked_text.side_effect = FileNotFoundError()
+        mocked_read_text.side_effect = FileNotFoundError()
 
         # call the method
         with self.assertRaisesRegex(
@@ -43,10 +43,10 @@ class GetJsonFileContentTestCase(TestCase):
             get_json_file_content(Path("path/to/file"))
 
     @patch("dakara_feeder.json.json.load")
-    def test_get_error_invalid(self, mocked_load, mocked_text):
+    def test_get_error_invalid(self, mocked_load, mocked_read_text):
         """Test to get an invalid JSON file."""
         # create the mock
-        mocked_text.return_value = "aaaaaaa"
+        mocked_read_text.return_value = "aaaaaaa"
 
         # call the method
         with self.assertRaisesRegex(
@@ -55,11 +55,11 @@ class GetJsonFileContentTestCase(TestCase):
         ):
             get_json_file_content(Path("path/to/file"))
 
-    def test_get_key(self, mocked_text):
+    def test_get_key(self, mocked_read_text):
         """Test to get the key of a JSON file."""
         # create the mock
         content = {"tags": {"name": "tag1"}}
-        mocked_text.return_value = dumps(content)
+        mocked_read_text.return_value = dumps(content)
 
         # call the method
         content_parsed = get_json_file_content(Path("path/to/file"), "tags")
@@ -68,13 +68,13 @@ class GetJsonFileContentTestCase(TestCase):
         self.assertDictEqual(content["tags"], content_parsed)
 
         # assert the call
-        mocked_text.assert_called_with()
+        mocked_read_text.assert_called_with()
 
-    def test_get_key_error(self, mocked_text):
+    def test_get_key_error(self, mocked_read_text):
         """Test to get a invalid key of a JSON file."""
         # create the mock
         content = {"tags": {"name": "tag1"}}
-        mocked_text.return_value = dumps(content)
+        mocked_read_text.return_value = dumps(content)
 
         # call the method
         with self.assertRaisesRegex(

--- a/tests/unit/test_yaml.py
+++ b/tests/unit/test_yaml.py
@@ -12,15 +12,15 @@ from dakara_feeder.yaml import (
 )
 
 
-@patch.object(Path, "text", autoset=True)
+@patch.object(Path, "read_text", autoset=True)
 class GetYamlFileContentTestCase(TestCase):
     """Test the get_yaml_file_content function."""
 
-    def test_get(self, mocked_text):
+    def test_get(self, mocked_read_text):
         """Test to get a YAML file."""
         # create the mock
         content = {"name": "tag1"}
-        mocked_text.return_value = yaml.safe_dump(content)
+        mocked_read_text.return_value = yaml.safe_dump(content)
 
         # call the method
         content_parsed = get_yaml_file_content(Path("path/to/file"))
@@ -29,12 +29,12 @@ class GetYamlFileContentTestCase(TestCase):
         self.assertDictEqual(content, content_parsed)
 
         # assert the call
-        mocked_text.assert_called_with()
+        mocked_read_text.assert_called_with()
 
-    def test_get_error_not_found(self, mocked_text):
+    def test_get_error_not_found(self, mocked_read_text):
         """Test to get a YAML file that does not exist."""
         # create the mock
-        mocked_text.side_effect = FileNotFoundError()
+        mocked_read_text.side_effect = FileNotFoundError()
 
         # call the method
         with self.assertRaisesRegex(
@@ -43,11 +43,11 @@ class GetYamlFileContentTestCase(TestCase):
             get_yaml_file_content(Path("path/to/file"))
 
     @patch("dakara_feeder.yaml.yaml.safe_load")
-    def test_get_error_invalid(self, mocked_safe_load, mocked_text):
+    def test_get_error_invalid(self, mocked_safe_load, mocked_read_text):
         """Test to get an invalid YAML file."""
         # create the mock
         content = [{"name": "tag1"}]
-        mocked_text.return_value = yaml.safe_dump(content)
+        mocked_read_text.return_value = yaml.safe_dump(content)
         mocked_safe_load.side_effect = yaml.YAMLError("error message")
 
         # call the method
@@ -57,11 +57,11 @@ class GetYamlFileContentTestCase(TestCase):
         ):
             get_yaml_file_content(Path("path/to/file"))
 
-    def test_get_key(self, mocked_text):
+    def test_get_key(self, mocked_read_text):
         """Test to get the key of a YAML file."""
         # create the mock
         content = {"tags": {"name": "tag1"}}
-        mocked_text.return_value = yaml.safe_dump(content)
+        mocked_read_text.return_value = yaml.safe_dump(content)
 
         # call the method
         content_parsed = get_yaml_file_content(Path("path/to/file"), "tags")
@@ -70,13 +70,13 @@ class GetYamlFileContentTestCase(TestCase):
         self.assertDictEqual(content["tags"], content_parsed)
 
         # assert the call
-        mocked_text.assert_called_with()
+        mocked_read_text.assert_called_with()
 
-    def test_get_key_error(self, mocked_text):
+    def test_get_key_error(self, mocked_read_text):
         """Test to get a invalid key of a YAML file."""
         # create the mock
         content = {"tags": {"name": "tag1"}}
-        mocked_text.return_value = str(content)
+        mocked_read_text.return_value = str(content)
 
         # call the method
         with self.assertRaisesRegex(


### PR DESCRIPTION
Fix #20.

Difficulties:

- [ ] ffprobe:
  - [ ] Can't install with `brew install ffmpeg`, leads to an error when executing the formula (see [logs](https://ci.appveyor.com/project/neraste/dakara-feeder/builds/43386218/job/pa674pxkt7re3cjb));
- [ ] mediainfo:
  - [x] Install with `brew install mediainfo --cask`; 
  - [ ] Cannot access to program version (`mediainfo --version`), binary not in PATH (see [logs](https://ci.appveyor.com/project/neraste/dakara-feeder/builds/43389451/job/yrhluqa2c30h0hhm)).