### PR TITLE
Drop Python 3.7 support and add Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           - macos-latest
           - windows-latest
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install native dependencies (Ubuntu)
@@ -95,7 +95,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Added
 
 - MacOS support.
+- Added Python 3.12 support.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 
 - MacOS support.
 
+### Removed
+
+- Dropped Python 3.7 support.
+
 ## 1.8.0 - 2022-11-23
 
 ### Update notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Operating System :: OS Independent",
         "Environment :: Console",
         "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,11 @@ description = "External database feeder for the Dakara Project"
 readme = "README.md"
 license = {file = "LICENSE"}
 dynamic = ["version"]
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 classifiers = [
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -25,7 +24,6 @@ classifiers = [
 dependencies = [
         "dakarabase>=1.4.2,<1.5.0",
         "filetype>=1.2.0,<1.3.0",
-        "importlib-resources>=5.10.0,<5.11.0",
         "path>=16.4.0,<16.5.0",
         "pymediainfo>=5.1.0,<5.2.0",
         "pysubs2>=1.5.0,<1.6.0",


### PR DESCRIPTION
This MR aims to drop the latest unsupported Python version (3.7) and support the latest version (3.12).

This MR may need the latest `dakara-base` version, to support the in-house implementation of `strtobool`.